### PR TITLE
Pyproject doc link fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Nikhil Iyer <iyer.h.nikhil@gmail.com>", "Hammad Nasir <hammadn99@gma
 readme = "README.md"
 packages = [{include = "manim_data_structures", from = "src"}]
 repository = "https://github.com/ufosc/manim-data-structures"
-documentation = "https://manim-data-structures.readthedocs.io/en/latest/"
+documentation = "https://docs.manim.community/en/stable/"
 
 [tool.poetry.dependencies]
 python = ">=3.8.0,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Nikhil Iyer <iyer.h.nikhil@gmail.com>", "Hammad Nasir <hammadn99@gma
 readme = "README.md"
 packages = [{include = "manim_data_structures", from = "src"}]
 repository = "https://github.com/ufosc/manim-data-structures"
-documentation = ""
+documentation = "https://manim-data-structures.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = ">=3.8.0,<3.11"


### PR DESCRIPTION
Poetry won't install properly if no link exists in the toml file. I've linked it to what is also placed on the repo.

<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/ufosc/manim-data-structures/blob/main/CONTRIBUTING.md -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This just adds a link to the manim-dsa documentation in the pyproject.toml file - I found that my poetry wouldn't work without it, and figured it might be a common issue for future installs.
<!--changelog-end-->

<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added code segments are adequately covered by tests
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
