### PR TITLE
Removed usage of Enum in MArrayElementComp in favor of getters and setters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -65,6 +65,7 @@ PASTE HERE
 
 <details><summary>LaTeX details</summary>
 
+Output of `latex --version`:
 + LaTeX distribution (e.g. TeX Live 2020):
 + Installed LaTeX packages:
 <!-- output of `tlmgr list --only-installed` for TeX Live or a screenshot of the Packages page for MikTeX -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/drageelr/manim-data-structures/blob/main/CONTRIBUTING.md -->
+<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/ufosc/manim-data-structures/blob/main/CONTRIBUTING.md -->
 
 ## Overview: What does this pull request change?
 <!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
@@ -18,4 +18,5 @@
 <!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
 ## Reviewer Checklist
 - [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
+- [ ] If applicable: newly added code segments are adequately covered by tests
 - [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The general workflow for contributing to this project is as follows:
 To interact with the project, you will need to install some dependencies and configure git.
 
 1. [Install git](https://git-scm.com/)
-2. [Install Manim dependencies](https://docs.manim.community/en/stable/installation.html)
+2. [Install Manim dependencies](https://docs.manim.community/en/stable/installation.html#installing-manim-locally)
    - Note: You do not need to install Manim itself (Poetry will handle that).
 3. [Install Poetry](https://python-poetry.org/docs/master/#installing-with-the-official-installer)
 4. Fork the [project](https://github.com/ufosc/manim-data-structures).

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -310,13 +310,13 @@ class MArrayElement(VGroup):
             Mobject of the class.
         """
 
-        if mob_target == MArrayElementComp.BODY:
+        if mob_target == MArrayElementComp.get_body(self):
             return self.fetch_mob_square()
-        elif mob_target == MArrayElementComp.VALUE:
+        elif mob_target == MArrayElementComp.get_value(self):
             return self.fetch_mob_value()
-        elif mob_target == MArrayElementComp.INDEX:
+        elif mob_target == MArrayElementComp.get_index(self):
             return self.fetch_mob_index()
-        elif mob_target == MArrayElementComp.LABEL:
+        elif mob_target == MArrayElementComp.get_label(self):
             return self.fetch_mob_label()
         else:
             return self
@@ -807,7 +807,7 @@ class MArray(VGroup):
         removal_anim_args: dict = {},
         update_anim_args: dict = {},
         removal_anim_target: MArrayElementComp = None,
-        update_anim_target: MArrayElementComp = MArrayElementComp.INDEX,
+        update_anim_target: MArrayElementComp = MArrayElementComp.get_index(self),
     ) -> typing.Tuple[Succession, typing.Callable[[bool], typing.List[Animation]]]:
         """Removes the element from the array at the specified index.
 
@@ -1427,7 +1427,7 @@ class MArray(VGroup):
         removal_anim_args: dict = {},
         update_anim_args: dict = {},
         removal_anim_target: MArrayElementComp = None,
-        update_anim_target: MArrayElementComp = MArrayElementComp.INDEX,
+        update_anim_target: MArrayElementComp = MArrayElementComp.get_index(self),
         play_anim: bool = True,
         play_anim_args: dict = {},
     ) -> typing.Tuple[Succession, typing.Callable[[bool], typing.List[Animation]]]:

--- a/src/manim_data_structures/m_enum.py
+++ b/src/manim_data_structures/m_enum.py
@@ -5,19 +5,34 @@ from enum import Enum
 
 class MArrayElementComp(Enum):
     """Refers to individual component :class:`~manim.mobject.mobject.Mobject`\0s of :class:`~.m_array.MArrayElement`."""
+    def __init__(self):
+        self.BODY = 0
+        """:class:`~manim.mobject.geometry.polygram.Square` that represents the body."""
 
-    BODY = 0
-    """:class:`~manim.mobject.geometry.polygram.Square` that represents the body."""
+        self.VALUE = 1
+        """:class:`~manim.mobject.text.text_mobject.Text` that represents the value."""
 
-    VALUE = 1
-    """:class:`~manim.mobject.text.text_mobject.Text` that represents the value."""
+        self.INDEX = 2
+        """:class:`~manim.mobject.text.text_mobject.Text` that represents the index."""
 
-    INDEX = 2
-    """:class:`~manim.mobject.text.text_mobject.Text` that represents the index."""
-
-    LABEL = 3
-    """:class:`~manim.mobject.text.text_mobject.Text` that represents the label."""
-
+        self.LABEL = 3
+        """:class:`~manim.mobject.text.text_mobject.Text` that represents the label."""
+    def get_body(self):
+        return self.BODY
+    def get_value(self):
+        return self.VALUE
+    def get_index(self):
+        return self.INDEX
+    def get_label(self):
+        return self.LABEL
+    def set_body(self, body):
+        self.BODY = body
+    def set_value(self, value):
+        self.VALUE = value
+    def set_index(self, index):
+        self.INDEX = index
+    def set_label(self, label):
+        self.LABEL = label
 
 class MArrayDirection(Enum):
     """Serves as the direction for :class:`~.m_array.MArray`."""


### PR DESCRIPTION
## Motivation and Explanation: Why and how do your changes improve the library?
Adjusted MArrayElementComp to use getters and setters instead of Enum to better conform with Manim practices.
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added code segments are adequately covered by tests
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
