### PR TITLE
Update inheritance of several Mobjects from VGroup to VMobject

### DIFF
--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -11,7 +11,7 @@ from .m_enum import MArrayDirection, MArrayElementComp
 
 
 @utils.exclude_from_deepcopy("_MArrayElement__scene")
-class MArrayElement(VGroup):
+class MArrayElement(VMobject):
     """A class that represents an array element.
 
     Parameters
@@ -644,7 +644,7 @@ class MArrayElement(VGroup):
 
 
 @utils.exclude_from_deepcopy("_MArray__scene")
-class MArray(VGroup):
+class MArray(VMobject):
     """A class that represents an array.
 
     Parameters
@@ -1688,10 +1688,10 @@ class MArray(VGroup):
 
         anim: CyclicReplace = None
         if swap_body:
-            group_1 = VGroup(
+            group_1 = VMobject(
                 swap_elem_1.fetch_mob_body(), swap_elem_1.fetch_mob_value()
             )
-            group_2 = VGroup(
+            group_2 = VMobject(
                 swap_elem_2.fetch_mob_body(), swap_elem_2.fetch_mob_value()
             )
             anim = CyclicReplace(group_1, group_2, remover=True)
@@ -1725,7 +1725,7 @@ class MArray(VGroup):
 
 
 @utils.exclude_from_deepcopy("_MArrayPointer__scene", "_MArrayPointer__arr")
-class MArrayPointer(VGroup):
+class MArrayPointer(VMobject):
     """A class that represents a pointer.
 
     Parameters
@@ -2190,7 +2190,7 @@ class MArrayPointer(VGroup):
 
 
 @utils.exclude_from_deepcopy("_MArraySlidingWindow__scene", "_MArraySlidingWindow__arr")
-class MArraySlidingWindow(VGroup):
+class MArraySlidingWindow(VMobject):
     """A class that represents a sliding window
 
     Parameters


### PR DESCRIPTION
<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/ufosc/manim-data-structures/blob/main/CONTRIBUTING.md -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This PR resolves **Issue #3**, which addresses unnecessary inheritance from VGroup in several Mobjects. I replaced all instances of VGroup inheritance with VMobject to avoid unexpected behavior with operators and grouping functionality, as stated in the issue.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
The original use of VGroup was unnecessary and could cause issues with object grouping behaviors. I reviewed the VGroup methods from vectorized_mobject.py and verified that none of the affected Mobjects required VGroup's grouping-specific behaviors.  


## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->
I'm in the SWE class, so please let me know if something is incorrect. This is my first ever OSC contribution!


<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added code segments are adequately covered by tests
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
